### PR TITLE
Update delay comment in Vuex store

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -81,7 +81,7 @@ const store = createStore({
           setTimeout(async () => {
             const res = await axios.get("/api/offices");
             resolve(res);
-          }, 500); // Delay for 3 seconds
+          }, 500); // Delay for 500ms
         });
 
         commit("setOffices", response.data);


### PR DESCRIPTION
## Summary
- adjust fetch delay comment to match the 500 ms timeout

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e775f2070832f8cfc18aa5dfe18a6